### PR TITLE
[fix] メールアドレスが空のとき、エラーをひとつだけ表示

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,8 @@ class User < ApplicationRecord
   validates :user_name, presence: true, uniqueness: true
   validates :full_name, presence: true
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
-  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX },
+  validates :email, presence: true
+  validates :email, format: { with: VALID_EMAIL_REGEX, allow_blank: true },
                     uniqueness: { case_sensitive: false }
   validates :password, length: { minimum: 6 }, allow_nil: true
 


### PR DESCRIPTION
メールアドレスを空欄の状態で Submit すると、”メールアドレスを入力してください”, "メールアドレスは不正な値です"とふたつ表示されていたので、”メールアドレスを入力してください”とだけ表示されるようにしました。